### PR TITLE
Fix CAN -character hex code to correct one

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -56,7 +56,7 @@
 #define BS  0x08
 #define ETX 0x03
 #define TAB 0x09
-#define CAN 0x24
+#define CAN 0x18
 
 #define MAX_LINE 500
 #define MAX_ARGUMENTS 30


### PR DESCRIPTION
- 0x24 is '$' character, but CAN is 0x18 (24dec) .

@kuggenhoffen @kimlep01 
