### PR TITLE
Yotta specific include based on YOTTA_CFG flag

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -30,7 +30,7 @@
 #define FEA_TRACE_SUPPORT
 #include "ns_trace.h"
 
-#ifdef TARGET_LIKE_MBED
+#ifdef YOTTA_CFG
 #include "mbed-client-cli/ns_cmdline.h"
 #else
 #include "ns_cmdline.h"


### PR DESCRIPTION
Changed TARGET_LIKE_MBED flag to more generic Yotta specific build flag YOTTA_CFG to support eg. linux builds as well.
