### PR TITLE
Make the ns_cmdline.h self contained by adding include for stdbool.h

### DIFF
--- a/mbed-client-cli/ns_cmdline.h
+++ b/mbed-client-cli/ns_cmdline.h
@@ -97,6 +97,7 @@ extern "C" {
 #include <stdarg.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #define CMDLINE_RETCODE_COMMAND_BUSY            2   //!< Command Busy
 #define CMDLINE_RETCODE_EXCUTING_CONTINUE       1   //!< Execution continue in background


### PR DESCRIPTION
All the header files should be self contained, i.e they should not expect
any other (system) header files to be included before them.
