### PR TITLE
add MBED_CONF_MBED_TRACE_ENABLE trace enable flag support

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -41,7 +41,7 @@
 #ifndef NS_TRACE_USE_MBED_TRACE
 #define mbed_trace_exclude_filters_set set_trace_exclude_filters
 #endif
-#if (HAVE_DEBUG) || defined(FEA_TRACE_SUPPORT)
+#if (MBED_CONF_MBED_TRACE_ENABLE) || (HAVE_DEBUG) || defined(FEA_TRACE_SUPPORT)
 #define YOTTA_CFG_MBED_TRACE
 #endif
 #endif


### PR DESCRIPTION
Needed by ARMmbed/mbed-trace#32 for at least some builds.
