### PR TITLE
disable trace colors when disable vt100

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -1519,6 +1519,15 @@ int set_command(int argc, char *argv[])
         bool state;
         if (cmd_parameter_bool(argc, argv, "--vt100", &state)) {
             cmd.vt100_on = state;
+            
+            uint8_t cfg = mbed_trace_config_get();
+            if(state) {
+            	cfg |= TRACE_MODE_COLOR;
+            } else {
+            	cfg &=~ TRACE_MODE_COLOR;
+            }
+            mbed_trace_config_set(cfg);
+            
             return 0;
         }
         if (cmd_parameter_bool(argc, argv, "--retcode", &state)) {


### PR DESCRIPTION
`set --vt100 <bool>` will now activate/disable also color mode from trace library.

fix issue: https://github.com/ARMmbed/mbed-client-cli/issues/44
