### PR TITLE
Allow setting mutex locking/unlocking callbacks before cmd_init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This is the Command Line Library for a CLI application. This library provides me
 Command Line Library API is described in the snipplet below: 
 
 ```c++
+// if thread safety for CLI terminal output is needed
+// configure output mutex wait cb before initialization so it's available immediately
+cmd_set_mutex_wait_func( (func)(void) );
+// configure output mutex release cb before initialization so it's available immediately
+cmd_set_mutex_wait_func( (func)(void) );
 // initialize cmdline with print function
 cmd_init( (func)(const char* fmt, va_list ap) );
 // configure ready cb
@@ -21,11 +26,6 @@ cmd_set_ready_cb( (func)(int retcode)  );
 cmd_add( <command>, (int func)(int argc, char *argv[]), <help>, <man>); 
 //execute some existing commands
 cmd_exe( <command> );
-// if thread safety for CLI terminal output is needed
-// configure output mutex wait cb
-cmd_set_mutex_wait_func( (func)(void) );
-// configure output mutex release cb 
-cmd_set_mutex_wait_func( (func)(void) );
 ```
 
 ## Usage example
@@ -89,10 +89,10 @@ static void my_mutex_release(void)
 }
 
 void main(void) {
+   cmd_mutex_wait_func( my_mutex_wait ); // configure mutex wait function before initializing
+   cmd_mutex_release_func( my_mutex_release ); // configure mutex release function before initializing
    cmd_init( &myprint );              // initialize cmdline with print function
    cmd_set_ready_cb( cmd_ready_cb );  // configure ready cb.
-   cmd_mutex_wait_func( my_mutex_wait ); // configure mutex wait function
-   cmd_mutex_release_func( my_mutex_release ); // configure mutex release function
    //CLI terminal output now locks against MyMutex
 }
 

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -237,8 +237,6 @@ void cmd_init(cmd_print_t *outf)
     mbed_trace_exclude_filters_set(TRACE_GROUP);
     cmd.out = outf ? outf : default_cmd_response_out;
     cmd.ctrl_fnc = NULL;
-    cmd.mutex_wait_fnc = NULL;
-    cmd.mutex_release_fnc = NULL;
     cmd.echo = true;
     cmd.print_retcode = false;
     cmd.escaping = false;
@@ -315,6 +313,8 @@ void cmd_free(void)
         ns_list_remove(&cmd.history_list, cur_ptr);
         MEM_FREE(cur_ptr);
     }
+    cmd.mutex_wait_fnc = NULL;
+    cmd.mutex_release_fnc = NULL;
 }
 void cmd_exe(char *str)
 {


### PR DESCRIPTION
Calling cmd_init() set the callbacks to NULL so they had to be set after initializing the library.
This left a small window of time during which cli output could happen without any thread safety being in place.
