### PR TITLE
Let the possibility to the user to define the maximum size a line can takes.

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -77,7 +77,10 @@
 #define TAB 0x09
 #define CAN 0x18
 
+#ifndef MAX_LINE
 #define MAX_LINE 2000
+#endif
+
 #define MAX_ARGUMENTS 30
 
 //include manuals or not (save memory a little when not include)


### PR DESCRIPTION
If ns_cmdline.c is compiled while MAX_LINE is defined with a value;
then the value defined by the user will be used to allocates line buffer.
