### PR TITLE
Add support for redirecting input to buffer

### DIFF
--- a/mbed-client-cli/ns_cmdline.h
+++ b/mbed-client-cli/ns_cmdline.h
@@ -256,7 +256,7 @@ void cmd_char_input(int16_t u_data);
  * \param redir_buf Buffer where incoming characters should be redirected to
  * \param redir_len Number of characters to redirect
  */
-bool cmd_redirect(char *redir_buf, const int redir_len);
+bool cmd_redirect(char *redir_buf, const size_t redir_len);
 
 /* Methods used for adding and handling of commands and aliases
  */

--- a/mbed-client-cli/ns_cmdline.h
+++ b/mbed-client-cli/ns_cmdline.h
@@ -249,7 +249,14 @@ void cmd_echo_on(void);
  * \param u_data char to be added to console
  */
 void cmd_char_input(int16_t u_data);
-
+/*
+ * Configure input to work in redirection mode. In redirection mode any characters input using cmd_char_input function
+ * are appended to redir_buf until redir_len bytes have been received after which the redirection mode is disabled and normal command
+ * mode is resumed.
+ * \param redir_buf Buffer where incoming characters should be redirected to
+ * \param redir_len Number of characters to redirect
+ */
+bool cmd_redirect(char *redir_buf, const int redir_len);
 
 /* Methods used for adding and handling of commands and aliases
  */

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -160,7 +160,7 @@ typedef struct cmd_class_s {
     bool escaping;                    // escaping input
     bool insert;                      // insert enabled
     bool redirecting;
-    int redirecting_count;
+    size_t redirecting_count;
     char *redirecting_buf;
     int  tab_lookup;                  // originally lookup characters count
     int  tab_lookup_cmd_n;            // index in command list
@@ -351,9 +351,9 @@ void cmd_free(void)
     cmd.mutex_release_fnc = NULL;
 }
 
-bool cmd_redirect(char *redir_buf, const int redir_len)
+bool cmd_redirect(char *redir_buf, const size_t redir_len)
 {
-    if (cmd.redirecting || redir_buf == NULL || redir_len <= 0) {
+    if (cmd.redirecting || redir_buf == NULL || redir_len == 0) {
         return false;
     }
     cmd.redirecting = true;

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -1046,7 +1046,6 @@ void cmd_char_input(int16_t u_data)
         // All bytes received, so clear redirecting variables and set flag to false
         cmd.redirecting_buf = NULL;
         cmd.redirecting = false;
-        cmd.redirecting_count = 0;
         return;
     }
 

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -159,6 +159,9 @@ typedef struct cmd_class_s {
     bool init;                        // true when lists are initialized already
     bool escaping;                    // escaping input
     bool insert;                      // insert enabled
+    bool redirecting;
+    int redirecting_count;
+    char *redirecting_buf;
     int  tab_lookup;                  // originally lookup characters count
     int  tab_lookup_cmd_n;            // index in command list
     int  tab_lookup_n;                //
@@ -278,6 +281,9 @@ void cmd_init(cmd_print_t *outf)
     cmd.cmd_buffer_ptr = 0;
     cmd.idle = true;
     cmd.ready_cb = cmd_next;
+    cmd.redirecting = false;
+    cmd.redirecting_count = 0;
+    cmd.redirecting_buf = NULL;
     cmd_set_retfmt("retcode: %i\r\n");
     cmd_line_clear(0);            // clear line
     cmd_history_save(0);          // the current line is the 0 item
@@ -344,6 +350,18 @@ void cmd_free(void)
     cmd.mutex_wait_fnc = NULL;
     cmd.mutex_release_fnc = NULL;
 }
+
+bool cmd_redirect(char *redir_buf, const int redir_len)
+{
+    if (cmd.redirecting || redir_buf == NULL || redir_len <= 0) {
+        return false;
+    }
+    cmd.redirecting = true;
+    cmd.redirecting_count = redir_len;
+    cmd.redirecting_buf = redir_buf;
+    return true;
+}
+
 void cmd_exe(char *str)
 {
     cmd_split(str);
@@ -1016,6 +1034,22 @@ static void cmd_reset_tab(void)
 }
 void cmd_char_input(int16_t u_data)
 {
+    /*Handle redirecting*/
+    if (cmd.redirecting == true) {
+        // Append the character into redirect buffer and decrease counter
+        *(cmd.redirecting_buf)++ = u_data;
+        cmd.redirecting_count--;
+        if (cmd.redirecting_count > 0) {
+            // Bytes left to read, so return immediately
+            return;
+        }
+        // All bytes received, so clear redirecting variables and set flag to false
+        cmd.redirecting_buf = NULL;
+        cmd.redirecting = false;
+        cmd.redirecting_count = 0;
+        return;
+    }
+
     /*handle ecape command*/
     if (cmd.escaping == true) {
         cmd_escape_read(u_data);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -714,4 +714,33 @@ TEST(cli, ampersand)
     REQUEST("echo hello world&");
     ARRAY_CMP(RESPONSE("hello world ") , buf);
 }
+#define REDIR_DATA "echo Hi!"
+TEST(cli, redirecting)
+{
+    bool ok;
+    int buflen = 100;
+    char* redirbuf = (char*)malloc(buflen);
+    memset(redirbuf, 0, buflen);
 
+    // NULL buffer, should not enable redirect
+    ok = cmd_redirect(NULL, 1);
+    CHECK_EQUAL(false, ok);
+    REQUEST(REDIR_DATA);
+    ARRAY_CMP(RESPONSE("Hi! ") , buf);
+
+    // ZERO length should not enable redirect
+    ok = cmd_redirect(buf, 0);
+    CHECK_EQUAL(false, ok);
+    REQUEST(REDIR_DATA);
+    ARRAY_CMP(RESPONSE("Hi! ") , buf);
+
+    // buf and length ok, redirect should be enabled, buf should be 0 and bytes should go to redirect buffer
+    INIT_BUF();
+    ok = cmd_redirect(redirbuf, strlen(REDIR_DATA));
+    CHECK_EQUAL(true, ok);
+    input(REDIR_DATA);
+    CHECK(strlen(buf) == 0);
+    ARRAY_CMP(REDIR_DATA, redirbuf);
+    REQUEST(REDIR_DATA);
+    ARRAY_CMP(RESPONSE("Hi! ") , buf);
+}

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -715,12 +715,9 @@ TEST(cli, ampersand)
     ARRAY_CMP(RESPONSE("hello world ") , buf);
 }
 #define REDIR_DATA "echo Hi!"
-TEST(cli, redirecting)
+TEST(cli, redirecting_null_buffer)
 {
     bool ok;
-    int buflen = 100;
-    char* redirbuf = (char*)malloc(buflen);
-    memset(redirbuf, 0, buflen);
 
     // NULL buffer, should not enable redirect
     ok = cmd_redirect(NULL, 1);
@@ -728,12 +725,26 @@ TEST(cli, redirecting)
     REQUEST(REDIR_DATA);
     ARRAY_CMP(RESPONSE("Hi! ") , buf);
 
+}
+TEST(cli, redirecting_zero_length)
+{
+    bool ok;
+    int buflen = 100;
+    char* redirbuf = (char*)malloc(buflen);
+    memset(redirbuf, 0, buflen);
     // ZERO length should not enable redirect
     ok = cmd_redirect(buf, 0);
     CHECK_EQUAL(false, ok);
     REQUEST(REDIR_DATA);
     ARRAY_CMP(RESPONSE("Hi! ") , buf);
-
+    free(redirbuf);
+}
+TEST(cli, redirecting_success)
+{
+    bool ok;
+    int buflen = 100;
+    char* redirbuf = (char*)malloc(buflen);
+    memset(redirbuf, 0, buflen);
     // buf and length ok, redirect should be enabled, buf should be 0 and bytes should go to redirect buffer
     INIT_BUF();
     ok = cmd_redirect(redirbuf, strlen(REDIR_DATA));
@@ -743,4 +754,5 @@ TEST(cli, redirecting)
     ARRAY_CMP(REDIR_DATA, redirbuf);
     REQUEST(REDIR_DATA);
     ARRAY_CMP(RESPONSE("Hi! ") , buf);
+    free(redirbuf);
 }


### PR DESCRIPTION
Introduce a new redirection mode. Redirection mode can be used to transmit any number of raw bytes into the application. To enable redirection mode, a new function `cmd_redirect` is called with a pointer to a buffer and length as parameters. When redirection mode is enabled, all characters received are appended to the redirection buffer until length bytes have been received.