### PR TITLE
Implement input passthrough callback mode

### DIFF
--- a/mbed-client-cli/ns_cmdline.h
+++ b/mbed-client-cli/ns_cmdline.h
@@ -249,7 +249,13 @@ void cmd_echo_on(void);
  * \param u_data char to be added to console
  */
 void cmd_char_input(int16_t u_data);
-
+/*
+ * Set the passthrough mode callback function. In passthrough mode normal command input handling is skipped and any
+ * received characters are passed to the passthrough callback function. Setting this to null will disable passthrough mode.
+ * \param passthrough_fnc The passthrough callback function
+ */
+typedef void (*input_passthrough_func_t)(uint8_t c);
+void cmd_input_passthrough_func(input_passthrough_func_t passthrough_fnc);
 
 /* Methods used for adding and handling of commands and aliases
  */

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -571,16 +571,15 @@ static cmd_command_t *cmd_find_n(char *name, int nameLength, int n)
 {
     cmd_command_t *cmd_ptr = NULL;
     int i = 0;
-    if (name == NULL || nameLength == 0) {
-        return NULL;
-    }
-    ns_list_foreach(cmd_command_t, cur_ptr, &cmd.command_list) {
-        if (strncmp(name, cur_ptr->name_ptr, nameLength) == 0) {
-            if (i == n) {
-                cmd_ptr = cur_ptr;
-                break;
+    if (name != NULL && nameLength != 0) {
+        ns_list_foreach(cmd_command_t, cur_ptr, &cmd.command_list) {
+            if (strncmp(name, cur_ptr->name_ptr, nameLength) == 0) {
+                if (i == n) {
+                    cmd_ptr = cur_ptr;
+                    break;
+                }
+                i++;
             }
-            i++;
         }
     }
     return cmd_ptr;

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -743,3 +743,25 @@ TEST(cli, passthrough_set)
     ARRAY_CMP(RESPONSE("Hi! ") , buf);
 }
 
+
+TEST(cli, cmd_out_func_set_null)
+{
+    cmd_out_func(NULL);
+}
+
+static int outf_called = 0;
+void outf(const char *fmt, va_list ap) {
+    outf_called++;
+}
+TEST(cli, cmd_out_func_set)
+{
+    outf_called = 0;
+    cmd_out_func(&outf);
+    cmd_vprintf(NULL, NULL);
+    CHECK_EQUAL(outf_called, 1);
+}
+
+TEST(cli, cmd_ctrl_func_set_null)
+{
+    cmd_ctrl_func(NULL);
+}

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -776,3 +776,10 @@ TEST(cli, cmd_history_size_set)
     cmd_history_size(0);
     CHECK_EQUAL(cmd_history_size(1), 1);
 }
+
+TEST(cli, cmd_add_invalid_params)
+{
+    cmd_add(NULL, cmd_dummy, NULL, NULL);
+    cmd_add("", cmd_dummy, NULL, NULL);
+    cmd_add("abc", NULL, NULL, NULL);
+}

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -715,3 +715,31 @@ TEST(cli, ampersand)
     ARRAY_CMP(RESPONSE("hello world ") , buf);
 }
 
+#define REDIR_DATA "echo Hi!"
+#define PASSTHROUGH_BUF_LENGTH 10
+char passthrough_buffer[PASSTHROUGH_BUF_LENGTH];
+char* passthrough_ptr = NULL;
+void passthrough_cb(uint8_t c)
+{
+    if (passthrough_ptr != NULL) {
+        *passthrough_ptr++ = c;
+    }
+}
+TEST(cli, passthrough_set)
+{
+    passthrough_ptr = passthrough_buffer;
+    memset(&passthrough_buffer, 0, PASSTHROUGH_BUF_LENGTH);
+    INIT_BUF();
+
+    cmd_input_passthrough_func(passthrough_cb);
+    input(REDIR_DATA);
+
+    CHECK(strlen(buf) == 0);
+    ARRAY_CMP(REDIR_DATA, passthrough_buffer);
+
+    cmd_input_passthrough_func(NULL);
+
+    REQUEST(REDIR_DATA);
+    ARRAY_CMP(RESPONSE("Hi! ") , buf);
+}
+

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -770,3 +770,9 @@ TEST(cli, cmd_delete_null)
 {
     cmd_delete(NULL);
 }
+
+TEST(cli, cmd_history_size_set)
+{
+    cmd_history_size(0);
+    CHECK_EQUAL(cmd_history_size(1), 1);
+}

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -765,3 +765,8 @@ TEST(cli, cmd_ctrl_func_set_null)
 {
     cmd_ctrl_func(NULL);
 }
+
+TEST(cli, cmd_delete_null)
+{
+    cmd_delete(NULL);
+}


### PR DESCRIPTION
More generic method for passing arbitrary data to application. Application can use `cmd_input_passthrough_func` to set a passthrough callback function, which get's called for each character the cli receives with `cmd_char_input`.