### PR TITLE
Constify key param of cmd_has_option()

### DIFF
--- a/mbed-client-cli/ns_cmdline.h
+++ b/mbed-client-cli/ns_cmdline.h
@@ -346,7 +346,7 @@ int cmd_parameter_index(int argc, char *argv[], const char *key);
  * \param key   option key to be find
  * \return true if option found otherwise false
  */
-bool cmd_has_option(int argc, char *argv[], char *key);
+bool cmd_has_option(int argc, char *argv[], const char *key);
 /** find command parameter by key.
  * if exists, return true, otherwise false.
  * e.g. cmd: "mycmd enable 1"

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -1664,7 +1664,7 @@ int cmd_parameter_index(int argc, char *argv[], const char *key)
     }
     return -1;
 }
-bool cmd_has_option(int argc, char *argv[], char *key)
+bool cmd_has_option(int argc, char *argv[], const char *key)
 {
     int i = 0;
     for (i = 1; i < argc; i++) {


### PR DESCRIPTION
No need to have the key-parameter non-const as it will not be
modified by cmd_has_option() and the compiler will complain
if function is used with string literals in C++.