### PR TITLE
Update CLI to be comptabile with mbed-os logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ cmd_add( <command>, (int func)(int argc, char *argv[]), <help>, <man>);
 cmd_exe( <command> );
 ```
 
+## Tracing
+
+Command Line Library has trace messages, which are disabled by default.
+"MBED_CLIENT_CLI_TRACE_ENABLE" flag if defined, enables all the trace prints for debugging.
+
 ## Usage example
 
 Adding new commands to the Command Line Library and executing the commands:

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -54,10 +54,20 @@
 //#define TRACE_DEEP
 //#define TRACE_PRINTF
 
-
 #ifdef TRACE_PRINTF
 #undef tr_debug
 #define tr_debug(...) printf( __VA_ARGS__);printf("\r\n")
+#endif
+
+#ifndef MBED_CLIENT_CLI_TRACE_ENABLE
+#undef tr_error
+#define tr_error(...)
+#undef tr_warn
+#define tr_warn(...)
+#undef tr_debug
+#define tr_debug(...)
+#undef tr_info
+#define tr_info(...)
 #endif
 
 #ifdef TRACE_DEEP
@@ -65,7 +75,6 @@
 #else
 #define tr_deep(...)
 #endif
-
 
 #define TRACE_GROUP "cmdL"
 
@@ -263,7 +272,6 @@ void cmd_init(cmd_print_t *outf)
         ns_list_init(&cmd.cmd_buffer);
         cmd.init = true;
     }
-    mbed_trace_exclude_filters_set(TRACE_GROUP);
     cmd.out = outf ? outf : default_cmd_response_out;
     cmd.ctrl_fnc = NULL;
     cmd.echo = true;

--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -59,6 +59,8 @@
 #define tr_debug(...) printf( __VA_ARGS__);printf("\r\n")
 #endif
 
+// MBED_CLIENT_CLI_TRACE_ENABLE is to enable the traces for debugging,
+// default all debug traces are disabled.
 #ifndef MBED_CLIENT_CLI_TRACE_ENABLE
 #undef tr_error
 #define tr_error(...)


### PR DESCRIPTION
Unified logging in mbed-os provides logging API;s compatible with mbed_trace library. But features like filtering is not supported in similar manner as runtime option.

Changes in this PR are to disable trace logging at compile time, which was earlier done runtime at https://github.com/ARMmbed/mbed-client-cli/blob/master/source/ns_cmdline.c#L266

This fix is required for CI success in https://github.com/ARMmbed/mbed-os/pull/5965 

CC @sg- @SenRamakri @SeppoTakalo 