### PR TITLE
workaround for os5 compiling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ void main(void) {
 }
 ```
 
+
 ## Unit tests
 
 To run unit tests:

--- a/example/mbed-os-5/mbed-client-cli.lib
+++ b/example/mbed-os-5/mbed-client-cli.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-cli
+https://github.com/ARMmbed/mbed-client-cli#4c44e6c98f5c01a578477d73ebfa7b6ed87c1fed


### PR DESCRIPTION
## Status
**IN PROGRESS**

## description
There is known issue that causes that repository cannot contains library and application:
https://github.com/ARMmbed/mbed-cli/issues/407
This PR aim is to provide workaround to avoid compiling issues by using mbed-client-cli.lib in example which points to old commit that doesn't have yet mbed-os-5 example..