### PR TITLE
Use malloc with mbed OS targets

### DIFF
--- a/source/ns_cmdline.c
+++ b/source/ns_cmdline.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix) || defined(YOTTA_CFG) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix) || defined(MBED_CONF_RTOS_PRESENT) || defined(__APPLE__)
 #include <stdlib.h> //malloc
 #ifndef MEM_ALLOC
 #define MEM_ALLOC malloc


### PR DESCRIPTION
Replace old macro YOTTA_CFG with MBED_CONF_RTOS_PRESENT to use malloc instead
of nsdynmemLIB with mbed OS targets