### PR TITLE
ignore LF if CR was received previous

### DIFF
--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -320,6 +320,18 @@ TEST(cli, cmd_echo)
     ARRAY_CMP(RESPONSE("Hi! ") , buf);
     CHECK_RETCODE(0);
 }
+TEST(cli, cmd_echo_with_cr)
+{
+    input("echo crlf");INIT_BUF();input("\r\n");
+    ARRAY_CMP(RESPONSE("crlf ") , buf);
+    CHECK_RETCODE(0);
+}
+TEST(cli, cmd_echo_cr_only)
+{
+    input("echo cr");INIT_BUF();input("\r");
+    ARRAY_CMP(RESPONSE("cr ") , buf);
+    CHECK_RETCODE(0);
+}
 TEST(cli, cmd_echo1)
 {
     REQUEST(" echo Hi!");


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
see title - LF does not trigger execution if CR was received earlier. This way we can support all CR-LF combinations - different terminals uses different line feeds by defaults and it causes less confusion if this library support all of them (CR-LF, CR, LF). Note that LF-CR is not supported combination now.