### PR TITLE
workaround for issue #81

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,10 +94,14 @@ def morpheusBuildStep(target, compilerLabel, toolchain) {
           }
         }
         stage("build:example:${buildName}") {
-          dir("example/mbed-os-5") {
+          execute("mkdir ../example-mbed-os-5 || true")
+          execute("cp -R example/mbed-os-5 ../example-mbed-os-5")
+          dir("../example-mbed-os-5") {
             def exampleName = "example-${buildName}"
             setBuildStatus('PENDING', "build ${exampleName}", 'build starts')
             try {
+              execute("echo \"https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833\" > mbed-os.lib")
+              execute("echo \"https://github.com/ARMmbed/mbed-client-cli#${env.GIT_COMMIT_HASH}\" > mbed-clint-cli.lib")
               execute("mbed deploy")
               execute("mbed compile -t ${toolchain} -m ${target}")
               setBuildStatus('SUCCESS', "build ${exampleName}", "build done")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,7 @@ def morpheusBuildStep(target, compilerLabel, toolchain) {
             try {
               execute("echo \"https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833\" > mbed-os.lib")
               execute("echo \"https://github.com/ARMmbed/mbed-client-cli#${env.GIT_COMMIT_HASH}\" > mbed-clint-cli.lib")
+              execute("mbed new .")
               execute("mbed deploy")
               execute("mbed compile -t ${toolchain} -m ${target}")
               setBuildStatus('SUCCESS', "build ${exampleName}", "build done")

--- a/example/mbed-os-5/README.md
+++ b/example/mbed-os-5/README.md
@@ -17,3 +17,17 @@ When you flash a target with this application and open a terminal you should see
 >
 ...
 ```
+
+
+## build steps for workaround for issue #81 (PR #82)
+
+For the reason descript in [issue #81](https://github.com/ARMmbed/mbed-client-cli/issues/81), example folder moved out
+of repository.
+For cases like this, build steps are:
+1. go to new example folder
+2. check the revision and create `mbed-os.lib` and `mbed-client-cli.lib` lib files.
+3. `mbed new .` or `mbed config root .` to make current directory import libs, then
+```
+mbed deploy
+mbed compile -t GCC_ARM -m K64F
+```

--- a/example/mbed-os-5/mbed-client-cli.lib
+++ b/example/mbed-os-5/mbed-client-cli.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-client-cli#4c44e6c98f5c01a578477d73ebfa7b6ed87c1fed

--- a/example/mbed-os-5/mbed-os.lib
+++ b/example/mbed-os-5/mbed-os.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
* remove lib files from mbed-os5 example
* configure CI job that compiles example:
  * move example out of repository and generate lib files.

**NOTE:** This is workaround for ARMmbed/mbed-cli#407 .

Fixes #81 