### PR TITLE
remove duplicate cli library from mbed-os

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ def morpheusBuildStep(target, compilerLabel, toolchain) {
               execute("echo \"https://github.com/ARMmbed/mbed-client-cli#${env.GIT_COMMIT_HASH}\" > mbed-clint-cli.lib")
               execute("mbed new .")
               execute("mbed deploy")
+              execute("rm -rf ./mbed-os/features/frameworks/mbed-client-cli")
               execute("mbed compile -t ${toolchain} -m ${target}")
               setBuildStatus('SUCCESS', "build ${exampleName}", "build done")
             } catch(err) {


### PR DESCRIPTION
## Status
**READY**

## Migrations
 NO

## Description
mbed-os 5.10 brings mbed-client-cli inside so need kind of hack to able to test only this repository version of mbed-client-cli..

**NOTE:** this is required before other PR's can be merged..