### PR TITLE
COMMON_PAL is not required anymore

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ def morpheusBuildStep(target, compilerLabel, toolchain) {
         stage ("build:${buildName}") {
           try{
             execute("mbed --version")
-            execute("echo https://github.com/armmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833 > mbed-os.lib")
+            execute("echo https://github.com/armmbed/mbed-os/#3d4582bda07654ef51eb2e39c6294a3d1499ab65 > mbed-os.lib")
             execute("mbed deploy")
             execute("mbed compile -m ${target} -t ${toolchain} --library")
             setBuildStatus('SUCCESS', "build ${buildName}", "build done")
@@ -100,7 +100,7 @@ def morpheusBuildStep(target, compilerLabel, toolchain) {
             def exampleName = "example-${buildName}"
             setBuildStatus('PENDING', "build ${exampleName}", 'build starts')
             try {
-              execute("echo \"https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833\" > mbed-os.lib")
+              execute("echo \"https://github.com/ARMmbed/mbed-os/#3d4582bda07654ef51eb2e39c6294a3d1499ab65\" > mbed-os.lib")
               execute("echo \"https://github.com/ARMmbed/mbed-client-cli#${env.GIT_COMMIT_HASH}\" > mbed-clint-cli.lib")
               execute("mbed new .")
               execute("mbed deploy")

--- a/example/mbed-os-5/mbed_app.json
+++ b/example/mbed-os-5/mbed_app.json
@@ -8,7 +8,6 @@
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
             "platform.stdio-buffered-serial": true,
-            "target.features_add": ["COMMON_PAL"],
             "mbed-trace.enable": 1
         }
     }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Update mbed-os for example build and remove COMMON_PAL requirement since it doesn't work anymore with it.